### PR TITLE
Fix in `onClientDisconnect`

### DIFF
--- a/space-tweet/server.js
+++ b/space-tweet/server.js
@@ -88,7 +88,7 @@ var listener = io.listen(server, {
 	},
 	
 	onClientDisconnect: function(client){
-	 clients.splice(clients.indexOf(client), 0);
+	 clients.splice(clients.indexOf(client), 1);
 	},
 
   onClientMessage: function(track){


### PR DESCRIPTION
`arr.splice(ndx, 0)` fails to remove the item at `ndx` in `arr`.
